### PR TITLE
Improve Travis CI setting and Git ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /vendor
+
+# PHPUnit
+.phpunit.result.cache
+
+# PHP CS Fixer
+.php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer install --prefer-dist --no-interaction


### PR DESCRIPTION
# Changed log

- Add `.phpunit.result.cache` file on `.gitignore` file because it's cached file generated by `PHPUnit`.
- Add `.php_cs.cache` file on `.gitignore` file because it's cached file generated by `PHP-CS-Fixer`.
- Add `php-7.4` version test during Travis CI build.